### PR TITLE
feat: update predict() based on recent update of the keras interface

### DIFF
--- a/beginner/Keras Neural Net.ipynb
+++ b/beginner/Keras Neural Net.ipynb
@@ -21,10 +21,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import syft.interfaces.keras as keras\n",
@@ -66,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -93,11 +91,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADiJJREFUeJzt3X2oHXV+x/HPx21MxIia5jZc4sNtfV6FJnKQYtVYFx+a\nfzSgEpGaQiQrMbjqIpVV2ET8I9Q1y4IPmFQxVk27oon+Ie2mQUgXVPYmpBpNW63c0ISY3JhqXAQf\nkm//uKNcs/fMOTlPc26+7xcc7rnznTnzdeLnzpz5zZnjiBCAfI6rugEA1SD8QFKEH0iK8ANJEX4g\nKcIPJFVJ+G1fZ/u/bH9o+/4qeqjH9ojtd21vsz1ccS/P2N5ne/u4aTNsb7T9QfHz1D7qbbnt3cW2\n22Z7fkW9nW77Ddvv237P9k+K6ZVuu5K+Ktlu7vU4v+0fSPpvSVdL2iXpd5JuiYj3e9pIHbZHJNUi\nYn8f9HKFpN9Lei4iLiqm/b2kAxGxsvjDeWpE/F2f9LZc0u8j4he97ueI3gYlDUbEVtsnSdoi6QZJ\nf6sKt11JXzergu1WxZ7/EkkfRsRHEfGVpH+SdH0FffS9iNgs6cARk6+XtLZ4vlZj//P0XJ3e+kJE\n7ImIrcXzzyXtkDRbFW+7kr4qUUX4Z0v633G/71KFG2ACIek3trfYXlJ1MxOYFRF7iucfS5pVZTMT\nWGb7neJtQSVvScazPSRprqS31Ufb7oi+pAq2Gyf8/tBlEXGxpL+WdGdxeNuXYuw9Wz9dn/2kpLMk\nzZG0R9KjVTZje7qklyXdHREHx9eq3HYT9FXJdqsi/LslnT7u99OKaX0hInYXP/dJWq+xtyn9ZG/x\n3vHb95D7Ku7nOxGxNyIORcRhSWtU4bazPUVjAXshIl4pJle+7Sbqq6rtVkX4fyfpHNt/avt4SQsl\nvVZBH3/A9onFiRjZPlHSNZK2ly/Vc69JWlQ8XyTp1Qp7+Z5vg1VYoIq2nW1LelrSjohYNa5U6bar\n11dl2y0iev6QNF9jZ/z/R9IDVfRQp68/k/QfxeO9qnuTtE5jh4Ffa+zcyGJJfyxpk6QPJP2bpBl9\n1Ns/SnpX0jsaC9pgRb1dprFD+nckbSse86vediV9VbLdej7UB6A/cMIPSIrwA0kRfiApwg8kRfiB\npCoNf59ePiupf3vr174kemtVVb1Vvefv238Q9W9v/dqXRG+tShl+ABVp6yIf29dJ+pWkH0j6h4hY\nWTb/zJkzY2ho6LvfR0dHNTAw0PL6u6lfe+vXviR6a1UnexsZGdH+/fvdzLx/1OpKiptyPK5xN+Ww\n/VqU3JRjaGhIw8OV3hwHOKbVarWm523nsJ+bcgCTWDvh7/ebcgAo0fUTfraX2B62PTw6Otrt1QFo\nUjvhb+qmHBGxOiJqEVHr1xMuQEbthL9vb8oBoLGWz/ZHxDe2l0n6V40N9T0TEe91rDMAXdVy+CUp\nIl6X9HqHegHQQ1zhByRF+IGkCD+QFOEHkiL8QFKEH0iK8ANJEX4gKcIPJEX4gaQIP5AU4QeSIvxA\nUoQfSIrwA0kRfiApwg8kRfiBpAg/kBThB5Ii/EBSbd29F2jH/v37S+t33HFHaf3ZZ58trU+fPv1o\nW0qFPT+QFOEHkiL8QFKEH0iK8ANJEX4gKcIPJHXMjPN/+eWXpfWvv/66tD516tTS+pQpU466J5Tb\ntGlTaX3Dhg2l9RdffLG0fvvtt9etHXcc+722wm97RNLnkg5J+iYiap1oCkD3dWLP/1cRUX6pFoC+\nw7EPkFS74Q9Jv7G9xfaSTjQEoDfaPey/LCJ22/4TSRtt/2dEbB4/Q/FHYYkknXHGGW2uDkCntLXn\nj4jdxc99ktZLumSCeVZHRC0iagMDA+2sDkAHtRx+2yfaPunb55KukbS9U40B6K52DvtnSVpv+9vX\neTEi/qUjXbXgqaeeKq3fe++9pfXnn3++tL5w4cKj7gnlLr744raWX7p0aWn9xhtvrFubMWNGW+s+\nFrQc/oj4SNKfd7AXAD3EUB+QFOEHkiL8QFKEH0iK8ANJHTMf6W1Xo2Gjs88+u26tVuPDjK345JNP\nqm4hNfb8QFKEH0iK8ANJEX4gKcIPJEX4gaQIP5AU4/yFgwcPltavu+66urWtW7eWLpv5DkZfffVV\n3dqKFSu6uu7169fXrS1evLir654M2PMDSRF+ICnCDyRF+IGkCD+QFOEHkiL8QFLHzDj/eeed19XX\n//TTT+vWHnjggdJl16xZU1qfNm1aSz1NBvv27atb27hxYw87wZHY8wNJEX4gKcIPJEX4gaQIP5AU\n4QeSIvxAUsfMOP/VV19dWn/iiSdK643u219m3bp1pfVbb721tF52r4DJ7uSTT65bu+CCC0qX3bFj\nR1vrXrBgQVvLH+sa7vltP2N7n+3t46bNsL3R9gfFz1O72yaATmvmsP9ZSUfumu6XtCkizpG0qfgd\nwCTSMPwRsVnSgSMmXy9pbfF8raQbOtwXgC5r9YTfrIjYUzz/WNKsejPaXmJ72Pbw6Ohoi6sD0Glt\nn+2PiJAUJfXVEVGLiNrAwEC7qwPQIa2Gf6/tQUkqftb/6BaAvtRq+F+TtKh4vkjSq51pB0CvNBzn\nt71O0pWSZtreJennklZK+rXtxZJ2Srq5m00247jjyv+O3XbbbaX1RtcBbN++vbRe5uGHHy6tz5s3\nr7R+wgkntLzuqn322Wd1a+2O46M9DcMfEbfUKf2ow70A6CEu7wWSIvxAUoQfSIrwA0kRfiCpY+Yj\nvY00uj32NddcU1pvZ6jvrbfeKq0fOHDkRye+b/bs2S2vu5FDhw6V1jds2NDW6z/33HNtLY/uYc8P\nJEX4gaQIP5AU4QeSIvxAUoQfSIrwA0mlGedv5Kqrriqtr1q1qmvr3rJlS2m90Tj/Rx99VLf25ptv\nli5b9pFbSbrrrrtK61WaO3duaX0yfxS6F9jzA0kRfiApwg8kRfiBpAg/kBThB5Ii/EBSjPMXGn1N\n9p133lm39thjj7W17iq/Svrw4cOl9Ua3RK/S1q1bS+ubN2+uW7v22ms73c6k07//sgC6ivADSRF+\nICnCDyRF+IGkCD+QFOEHkmKcv0n33Xdf3drjjz/ew046q9E4vu0eddJ5b7zxRt0a4/xN7PltP2N7\nn+3t46Ytt73b9rbiMb+7bQLotGYO+5+VNNHlb7+MiDnF4/XOtgWg2xqGPyI2Syr/PikAk047J/yW\n2X6neFtwar2ZbC+xPWx7eHR0tI3VAeikVsP/pKSzJM2RtEfSo/VmjIjVEVGLiNrAwECLqwPQaS2F\nPyL2RsShiDgsaY2kSzrbFoBuayn8tgfH/bpAUuvfXw2gEg3H+W2vk3SlpJm2d0n6uaQrbc+RFJJG\nJP24iz2iiy688MLSeqPrABYuXFhaP+WUU+rWli1bVrosuqth+CPilgkmP92FXgD0EJf3AkkRfiAp\nwg8kRfiBpAg/kBQf6Z0EGl0Zef7559etPfTQQ6XLXn755S311Kxdu3bVrTHUVy32/EBShB9IivAD\nSRF+ICnCDyRF+IGkCD+QFOP8TSoba7/nnntKl/3www9L6xdddFFpfenSpaX1wcHB0npWL730Ut3a\n8uXLS5edNm1ah7vpP+z5gaQIP5AU4QeSIvxAUoQfSIrwA0kRfiApxvmbNHXq1Lq1Rx55pIedoFk7\nd+6sWzt06FAPO+lP7PmBpAg/kBThB5Ii/EBShB9IivADSRF+IKlmvqL7dEnPSZqlsa/kXh0Rv7I9\nQ9I/SxrS2Nd03xwR/9e9VjEZTZ8+vW7ttNNOK1227J7/7VqxYkVpfeXKlaX1Rl9dPhk081/wjaSf\nRsQPJf2FpDtt/1DS/ZI2RcQ5kjYVvwOYJBqGPyL2RMTW4vnnknZImi3peklri9nWSrqhW00C6Lyj\nOnaxPSRprqS3Jc2KiD1F6WONvS0AMEk0HX7b0yW9LOnuiDg4vhYRobHzARMtt8T2sO3h0dHRtpoF\n0DlNhd/2FI0F/4WIeKWYvNf2YFEflLRvomUjYnVE1CKi1ugLJwH0TsPw27akpyXtiIhV40qvSVpU\nPF8k6dXOtwegWzx2xF4yg32ZpH+X9K6kw8Xkn2nsff+vJZ0haafGhvoOlL1WrVaL4eHhdnvGMWJk\nZKS0Pm/evNL67t27O9jN933xxRel9eOPP75r625HrVbT8PCwm5m34Th/RPxWUr0X+9HRNAagf0z+\nKxUAtITwA0kRfiApwg8kRfiBpAg/kBS37kZlhoaGSuubN28urV966aWl9b179x5tS99pdA3Cueee\n2/Jr9wv2/EBShB9IivADSRF+ICnCDyRF+IGkCD+QFOP86FtnnnlmaX3dunWl9QcffLBu7aabbipd\nttE1CMcC9vxAUoQfSIrwA0kRfiApwg8kRfiBpAg/kBTj/Ji0rrjiitJ6o/sBZMeeH0iK8ANJEX4g\nKcIPJEX4gaQIP5AU4QeSahh+26fbfsP2+7bfs/2TYvpy27ttbyse87vfLoBOaeYin28k/TQitto+\nSdIW2xuL2i8j4hfdaw9AtzQMf0TskbSneP657R2SZne7MQDddVTv+W0PSZor6e1i0jLb79h+xvap\nHe4NQBc1HX7b0yW9LOnuiDgo6UlJZ0mao7Ejg0frLLfE9rDt4dHR0Q60DKATmgq/7SkaC/4LEfGK\nJEXE3og4FBGHJa2RdMlEy0bE6oioRURtYGCgU30DaFMzZ/st6WlJOyJi1bjpg+NmWyBpe+fbA9At\nzZzt/0tJfyPpXdvbimk/k3SL7TmSQtKIpB93pUMAXdHM2f7fSvIEpdc73w6AXuEKPyApwg8kRfiB\npAg/kBThB5Ii/EBShB9IivADSRF+ICnCDyRF+IGkCD+QFOEHkiL8QFKOiN6tzB6VtLNnKwTyOTMi\nmrplVk/DD6B/cNgPJEX4gaQIP5AU4QeSIvxAUoQfSIrwA0kRfiApwg8k9f8BoyhM7IH+5gAAAABJ\nRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x10622fda0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show(x_train[20])"
    ]
@@ -111,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -120,7 +127,7 @@
        "4"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -141,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -170,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -190,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -217,162 +224,8 @@
     },
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "30477462d4e640fe9acb26a33a3754d1",
-       "version_major": 2,
-       "version_minor": 0
-      },
       "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cb57fba88d6b49c398818ff06210ed1b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "483b36a8b2ec44299215cc0b173a08ae",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb0484cf67ce42b5bf3993f5c5592f53",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3a563ffa86a647c488d77078e6f4b354",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c19fc8225b4d442390e8f2c0c4ee0f94",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "296ddd7fd22d4eaea40a54023541c130",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7edbae93d651439198b0e1d490dd9a0f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "65bff0f8b48a41aab480bf4c0a11a26e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c1e55e6810c744a7a2a2c7bb560f6bd2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36bb662e35f44194aa2c2ae0a6c034ba",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "A Jupyter Widget"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'12.54929'"
+       "'0.07030737'"
       ]
      },
      "execution_count": 8,
@@ -393,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -404,54 +257,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADdtJREFUeJzt3V2IXHWax/Hfo5u98OUibnrbxonTruRm8CWRsntgZKMM\nE7KN+HKhrMiQhY6diwgbmAslCiN4YZBoiCCGqO20i28DGk1EdscJosyNpAxtjOndNUpEQ6e7ogMa\nc5HRfuaiToae2PU/lapTdarzfD/QdNV5zul6cjq/PlXnf+pf5u4CEM95ZTcAoByEHwiK8ANBEX4g\nKMIPBEX4gaBKCb+ZrTWz/zOzw2Z2fxk9NGJmR8zsIzObNLNqyb2Mm9msmR2ct+wSM3vbzD7Jvi/t\nod4eMrOj2b6bNLORknpbbmbvmNkhM/vYzP4zW17qvkv0Vcp+s26P85vZ+ZL+X9KvJH0paZ+ku9z9\nUFcbacDMjkiquPvxHujlXyWdkPS8u1+VLXtU0tfuviX7w7nU3e/rkd4eknTC3bd2u58zehuQNODu\n+83sYkkfSLpN0n+oxH2X6OtOlbDfyjjyD0k67O6fufspSS9LurWEPnqeu78n6eszFt8qaSK7PaH6\nf56ua9BbT3D3aXffn93+VtKUpMtU8r5L9FWKMsJ/maQv5t3/UiXugAW4pD+Y2QdmNlZ2Mwvod/fp\n7PYxSf1lNrOAe83sQPayoJSXJPOZ2aCkVZLeVw/tuzP6kkrYb5zw+7Eb3P06Sf8maWP29LYnef01\nWy9dn/2UpCslrZQ0LemxMpsxs4skvSppk7t/M79W5r5boK9S9lsZ4T8qafm8+z/JlvUEdz+afZ+V\ntEv1lym9ZCZ77Xj6NeRsyf38jbvPuPsP7j4n6WmVuO/MbInqAXvB3V/LFpe+7xbqq6z9Vkb490la\nYWZXmNk/Svp3SbtL6ONHzOzC7ESMzOxCSWskHUxv1XW7Ja3Lbq+T9EaJvfyd08HK3K6S9p2ZmaRn\nJU25++PzSqXuu0Z9lbbf3L3rX5JGVD/j/6mkB8rooUFf/yLpw+zr47J7k/SS6k8D/6L6uZFRSf8k\naa+kTyT9UdIlPdTbf0n6SNIB1YM2UFJvN6j+lP6ApMnsa6TsfZfoq5T91vWhPgC9gRN+QFCEHwiK\n8ANBEX4gKMIPBFVq+Hv08llJvdtbr/Yl0Vuryuqt7CN/z/5C1Lu99WpfEr21KmT4AZSkrYt8zGyt\npO2Szpf0jLtvSa2/bNkyHxwc/Nv9Wq2mvr6+lh+/k3q1t17tS6K3VhXZ25EjR3T8+HFrZt1/aPVB\nskk5ntS8STnMbLcnJuUYHBxUtVrq5DjAOa1SqTS9bjtP+5mUA1jE2gl/r0/KASCh4yf8zGzMzKpm\nVq3Vap1+OABNaif8TU3K4e473b3i7pVePeECRNRO+Ht2Ug4A+Vo+2+/u35vZvZL+R/WhvnF3/7iw\nzgB0VMvhlyR3f0vSWwX1AqCLuMIPCIrwA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IivADQRF+\nICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0ER\nfiAowg8ERfiBoAg/EFRbH9FtZkckfSvpB0nfu3uliKYAdF5b4c/c5O7HC/g5ALqIp/1AUO2G3yX9\nwcw+MLOxIhoC0B3tPu2/wd2Pmtk/S3rbzP7X3d+bv0L2R2FMki6//PI2Hw5AUdo68rv70ez7rKRd\nkoYWWGenu1fcvdLX19fOwwEoUMvhN7MLzezi07clrZF0sKjGAHRWO0/7+yXtMrPTP+dFd//vQrpa\nZE6ePJms7969O1l/+eWX29o++x0syN1b3raZ7devX5+sj46ONqwNDw8nt0VntRx+d/9M0rUF9gKg\nixjqA4Ii/EBQhB8IivADQRF+IKgi3tgT3j333JOs5w3l5Q23tVvv1LaSND4+nqyn/u2ffvppclsu\nCussjvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBTj/AWYnp5O1ufm5pL1gYGBZP2mm25K1u++++6G\nta1btya3zTM1NZWsz87OJusnTpxoWHviiSeS2z788MPJOtrDkR8IivADQRF+ICjCDwRF+IGgCD8Q\nFOEHgmKcvwBbtmxJ1vfs2ZOsj42lP+ls+fLlZ93TaSMjI8l63jh9Xm9vvvnmWfd02jXXXNPytmgf\nR34gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIpx/gIMDQ21Ve+kU6dOJet51wHs378/Wc+b93/16tUN\na3fccUdyW3RW7pHfzMbNbNbMDs5bdomZvW1mn2Tfl3a2TQBFa+Zp/+8krT1j2f2S9rr7Ckl7s/sA\nFpHc8Lv7e5K+PmPxrZImstsTkm4ruC8AHdbqCb9+dz89cd0xSf2NVjSzMTOrmlm1Vqu1+HAAitb2\n2X53d0meqO9094q7V/jgRaB3tBr+GTMbkKTse/qtYQB6Tqvh3y1pXXZ7naQ3imkHQLfkjvOb2UuS\nbpS0zMy+lPRbSVsk/d7MRiV9LunOTjaJtGeeeaZhbceOHcltJycnk/W8cfy8et5cByhPbvjd/a4G\npV8W3AuALuLyXiAowg8ERfiBoAg/EBThB4LiLb2LwBdffJGsb9iwoWGtfgFmY3lDdXnbb968OVm/\n6qqrknWUhyM/EBThB4Ii/EBQhB8IivADQRF+ICjCDwTFOP8icOmllybr1113XcNau1Nv5xkfH0/W\nX3nllYa1++67L7lt3jUCw8PDyTrSOPIDQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCM8y8CS5YsSdb3\n7dvXsJaa1luSHn300WT98OHDyfqxY8eS9dR8AGNjYy1vK0kffvhhsn711Vcn69Fx5AeCIvxAUIQf\nCIrwA0ERfiAowg8ERfiBoCxvLLVIlUrFq9Vq1x4P+U6ePJmsf/XVV8n666+/nqxPTEw0rOV9PHje\n/81bbrklWd+1a1eyfi6qVCqqVqtNTdKQe+Q3s3EzmzWzg/OWPWRmR81sMvsaaadhAN3XzNP+30la\nu8Dybe6+Mvt6q9i2AHRabvjd/T1JX3ehFwBd1M4Jv3vN7ED2smBpo5XMbMzMqmZWrdVqbTwcgCK1\nGv6nJF0paaWkaUmPNVrR3Xe6e8XdK319fS0+HICitRR+d59x9x/cfU7S05KGim0LQKe1FH4zG5h3\n93ZJBxutC6A35Y7zm9lLkm6UtEzSjKTfZvdXSnJJRyRtcPfpvAdjnD+e1HUEDzzwQHLb7du3J+t5\nnzmwZ8+ehrWRkXNzdPpsxvlzJ/Nw97sWWPzsWXcFoKdweS8QFOEHgiL8QFCEHwiK8ANBMXU3SpM3\n9XbeUF5efcWKFWfdUyQc+YGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMb50VGpjwh/9913k9vmvd38\nnXfeSdYZ50/jyA8ERfiBoAg/EBThB4Ii/EBQhB8IivADQTHOj6S8j/DOm177wQcfbFjLez9+f39/\nsn7ttdcm60jjyA8ERfiBoAg/EBThB4Ii/EBQhB8IivADQeWO85vZcknPS+pX/SO5d7r7djO7RNIr\nkgZV/5juO939z51rFZ0wOzubrK9duzZZz5t7P/We/FWrViW35ePcO6uZI//3kn7j7j+T9HNJG83s\nZ5Lul7TX3VdI2pvdB7BI5Ibf3afdfX92+1tJU5Iuk3SrpIlstQlJt3WqSQDFO6vX/GY2KGmVpPcl\n9bv7dFY6pvrLAgCLRNPhN7OLJL0qaZO7fzO/5vUXdgu+uDOzMTOrmlm1Vqu11SyA4jQVfjNbonrw\nX3D317LFM2Y2kNUHJC145sjdd7p7xd0rfX19RfQMoAC54bf6W6+elTTl7o/PK+2WtC67vU7SG8W3\nB6BTmnlL7y8k/VrSR2Y2mS3bLGmLpN+b2aikzyXd2ZkW0Y5NmzYl6+Pj48n6d999l6znvS13dHS0\nYe3JJ59MbovOyg2/u/9JUqPf8C+LbQdAt3CFHxAU4QeCIvxAUIQfCIrwA0ERfiAopu7uglOnTiXr\nGzdubOvnp8bq5+bmktued1767/8VV1yRrL/44ovJ+tDQULKO8nDkB4Ii/EBQhB8IivADQRF+ICjC\nDwRF+IGgGOfvgh07diTrzz33XLKemv5aSr+nPm8cf/369cn6tm3bkvULLrggWUfv4sgPBEX4gaAI\nPxAU4QeCIvxAUIQfCIrwA0Exzt8FMzMzyXreOH7eWPr111/fsPbII48ktx0eHk7Wce7iyA8ERfiB\noAg/EBThB4Ii/EBQhB8IivADQeWO85vZcknPS+qX5JJ2uvt2M3tI0j2Satmqm939rU41upitWbMm\nWT906FCyfvPNNyfro6OjZ90T0MxFPt9L+o277zeziyV9YGZvZ7Vt7r61c+0B6JTc8Lv7tKTp7Pa3\nZjYl6bJONwags87qNb+ZDUpaJen9bNG9ZnbAzMbNbGnBvQHooKbDb2YXSXpV0iZ3/0bSU5KulLRS\n9WcGjzXYbszMqmZWrdVqC60CoARNhd/Mlqge/Bfc/TVJcvcZd//B3eckPS1pwU9kdPed7l5x90pf\nX19RfQNoU274rT417LOSptz98XnLB+atdrukg8W3B6BTmjnb/wtJv5b0kZlNZss2S7rLzFaqPvx3\nRNKGjnR4Dli9enVbdaATmjnb/ydJC00Mz5g+sIhxhR8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4\ngaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAoy/t46EIfzKwm6fOuPSAQz0/dvakps7oafgC9g6f9QFCE\nHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUH8F+OtXHNRr4E0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11ce256d8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show(test[30])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "preds = model.predict(FloatTensor(x_test[:128],autograd=True))"
+    "preds = model.predict(x_test[:128])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([  4.44526600e-05,   1.60633700e-05,   4.21651000e-05,\n",
-       "         9.85654300e-01,   1.75880600e-06,   6.28078500e-03,\n",
-       "         9.88218400e-07,   5.24069000e-03,   8.55992100e-04,\n",
-       "         1.86282900e-03])"
+       "array([  1.89565100e-05,   3.64542300e-06,   8.90936100e-06,\n",
+       "         9.83649400e-01,   7.55119500e-07,   5.18625400e-03,\n",
+       "         5.28128600e-07,   7.34213600e-03,   6.82299100e-04,\n",
+       "         3.10703800e-03])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "preds.to_numpy()[30]"
+    "preds[30]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see, it is 98.5% sure that this is a 3!"
+    "As we can see, it is 98.4% sure that this is a 3!"
    ]
   },
   {
@@ -503,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello,

I have recently updated the predict function of the Keras interface. Now we can use directly a numpy array as an input instead of FLoatTensor. Predict() also output a numpy array so we don't have to transform the FloatTensor to numpy. For theses reasons, I have updated the predict section of this notebook.

Thank you!